### PR TITLE
Dev 1.0.1 dbchoe

### DIFF
--- a/frontend/src/logs/actions/index.ts
+++ b/frontend/src/logs/actions/index.ts
@@ -1023,7 +1023,9 @@ export const updateLogConfigAsync = (url: string, config: LogConfig) => async (
     await updateLogConfigAJAX(url, configForServer)
     dispatch(setConfig(config))
   } catch (error) {
-    dispatch(notify(notifyHttpErrorRespose(error.status, error.statusText)))
+    dispatch(
+      notify(notifyHttpErrorRespose(error.data.code, error.data.message))
+    )
     console.error(error)
   }
 }


### PR DESCRIPTION
If you click the Truncate and Wrap radio button on the Log Viewer Page as a viewer role, a 403 UnAuthorized error is displayed to the user.